### PR TITLE
FetchTransactionRequest now uses the order-management API when applicable

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -206,6 +206,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      */
     protected function getResponseBody(Response $response)
     {
-        return $response->json();
+        return empty($response->getBody(true)) ? [] : $response->json();
     }
 }

--- a/src/Message/FetchTransactionRequest.php
+++ b/src/Message/FetchTransactionRequest.php
@@ -21,11 +21,18 @@ final class FetchTransactionRequest extends AbstractRequest
      */
     public function sendData($data)
     {
-        $url = '/ordermanagement/v1/orders/'.$this->getTransactionReference();
+        $checkoutUrl = '/checkout/v3/orders/'.$this->getTransactionReference();
+        $checkoutResponseBody = $this->getResponseBody($this->sendRequest(RequestInterface::GET, $checkoutUrl, $data));
 
-        return new FetchTransactionResponse(
-            $this,
-            $this->getResponseBody($this->sendRequest(RequestInterface::GET, $url, $data))
-        );
+        if (isset($checkoutResponseBody['status']) && 'checkout_complete' === $checkoutResponseBody['status']) {
+            $managementUrl = '/ordermanagement/v1/orders/'.$this->getTransactionReference();
+
+            return new FetchTransactionResponse(
+                $this,
+                $this->getResponseBody($this->sendRequest(RequestInterface::GET, $managementUrl, $data))
+            );
+        }
+
+        return new FetchTransactionResponse($this, $checkoutResponseBody);
     }
 }

--- a/tests/Message/RequestTestCase.php
+++ b/tests/Message/RequestTestCase.php
@@ -40,6 +40,7 @@ abstract class RequestTestCase extends TestCase
     protected function setExpectedGetRequest(array $responseData, $url)
     {
         $response = \Mockery::mock(Response::class);
+        $response->shouldReceive('getBody')->with(true)->once()->andReturn(json_encode($responseData));
         $response->shouldReceive('json')->once()->andReturn($responseData);
 
         $request = \Mockery::mock(RequestInterface::class);
@@ -63,6 +64,7 @@ abstract class RequestTestCase extends TestCase
     protected function setExpectedPostRequest(array $inputData, array $responseData, $url)
     {
         $response = \Mockery::mock(Response::class);
+        $response->shouldReceive('getBody')->with(true)->once()->andReturn(json_encode($responseData));
         $response->shouldReceive('json')->once()->andReturn($responseData);
 
         $request = \Mockery::mock(RequestInterface::class);


### PR DESCRIPTION
The order management API should be used to fetch an order when a checkout order reaches the `checkout_complete` status.