### PR TITLE
Don't assume locale is provided when converting from Omnipay format to Klarna format

### DIFF
--- a/src/Message/AbstractOrderRequest.php
+++ b/src/Message/AbstractOrderRequest.php
@@ -156,13 +156,16 @@ abstract class AbstractOrderRequest extends AbstractRequest
     protected function getOrderData()
     {
         $data = [
-            'locale' => str_replace('_', '-', $this->getLocale()),
             'order_amount' => $this->getAmountInteger(),
             'order_tax_amount' => $this->toCurrencyMinorUnits($this->getTaxAmount()),
             'order_lines' => $this->getItemData($this->getItems()),
-            'purchase_country' => explode('_', $this->getLocale())[1],
             'purchase_currency' => $this->getCurrency(),
         ];
+
+        if (null !== $locale = $this->getLocale()) {
+            $data['locale'] = str_replace('_', '-', $locale);
+            $data['purchase_country'] = explode('_', $locale)[1];
+        }
 
         if (null !== $shippingCountries = $this->getShippingCountries()) {
             $data['shipping_countries'] = $shippingCountries;

--- a/tests/Message/UpdateTransactionRequestTest.php
+++ b/tests/Message/UpdateTransactionRequestTest.php
@@ -38,7 +38,6 @@ class UpdateTransactionRequestTest extends RequestTestCase
     {
         $this->updateTransactionRequest->initialize(
             [
-                'locale' => 'nl_NL',
                 'amount' => '100.00',
                 'tax_amount' => 21,
                 'currency' => 'EUR',
@@ -53,11 +52,9 @@ class UpdateTransactionRequestTest extends RequestTestCase
 
         self::assertEquals(
             [
-                'locale' => 'nl-NL',
                 'order_amount' => 10000,
                 'order_tax_amount' => 2100,
                 'order_lines' => [$this->getExpectedOrderLine()],
-                'purchase_country' => 'NL',
                 'purchase_currency' => 'EUR',
                 'gui' => ['options' => ['disable_autofocus', 'minimal_confirmation']],
                 'merchant_reference1' => '12345',


### PR DESCRIPTION
The `getOrderData` protected function is also used by `UpdateTransactionRequest`, where the locale is not required. Currenly `UpdateTransactionRequest` triggers an error, because it always assumes there's a locale provided.