### PR TITLE
Exception raised when an unexpected response such as unauthorized is received

### DIFF
--- a/src/Message/AuthorizeResponse.php
+++ b/src/Message/AuthorizeResponse.php
@@ -58,6 +58,7 @@ final class AuthorizeResponse extends AbstractResponse implements RedirectRespon
      */
     public function isSuccessful()
     {
-        return parent::isSuccessful() && 'checkout_incomplete' !== $this->data['status'];
+        // Authorize is only successful once it has been acknowledged
+        return false;
     }
 }

--- a/tests/Message/AuthorizeResponseTest.php
+++ b/tests/Message/AuthorizeResponseTest.php
@@ -25,28 +25,10 @@ class AuthorizeResponseTest extends TestCase
         self::assertTrue($response->isRedirect());
     }
 
-    /**
-     * @return array
-     */
-    public function responseDataProvider()
+    public function testIsSuccessfulWillAlwaysReturnFalse()
     {
-        return [
-            [['error_code' => 'oh_noes'], false],
-            [['status' => 'checkout_incomplete'], false],
-            [['status' => 'all_is_well'], true],
-        ];
-    }
+        $response = new AuthorizeResponse($this->getMockRequest(), []);
 
-    /**
-     * @dataProvider responseDataProvider
-     *
-     * @param array $responseData
-     * @param bool  $expected
-     */
-    public function testIsSuccessfulWillReturnWhetherResponseIsSuccessfull($responseData, $expected)
-    {
-        $response = new AuthorizeResponse($this->getMockRequest(), $responseData);
-
-        self::assertEquals($expected, $response->isSuccessful());
+        self::assertFalse($response->isSuccessful());
     }
 }

--- a/tests/Message/RequestTestCase.php
+++ b/tests/Message/RequestTestCase.php
@@ -36,10 +36,12 @@ abstract class RequestTestCase extends TestCase
     /**
      * @param array  $responseData
      * @param string $url
+     *
+     * @return \Mockery\MockInterface
      */
     protected function setExpectedGetRequest(array $responseData, $url)
     {
-        $this->setExpectedRequest(RequestInterface::GET, $url, [], [], $responseData);
+        return $this->setExpectedRequest(RequestInterface::GET, $url, [], [], $responseData);
     }
 
     /**
@@ -62,10 +64,12 @@ abstract class RequestTestCase extends TestCase
      * @param array  $inputData
      * @param array  $responseData
      * @param string $url
+     *
+     * @return \Mockery\MockInterface
      */
     protected function setExpectedPostRequest(array $inputData, array $responseData, $url)
     {
-        $this->setExpectedRequest(
+        return $this->setExpectedRequest(
             RequestInterface::POST,
             $url,
             ['Content-Type' => 'application/json'],
@@ -80,6 +84,8 @@ abstract class RequestTestCase extends TestCase
      * @param array  $headers
      * @param array  $inputData
      * @param array  $responseData
+     *
+     * @return \Mockery\MockInterface
      */
     private function setExpectedRequest($requestMethod, $url, array $headers, array $inputData, array $responseData)
     {
@@ -98,5 +104,7 @@ abstract class RequestTestCase extends TestCase
                 json_encode($inputData),
                 ['auth' => [self::MERCHANT_ID, self::SECRET]]
             )->andReturn($request);
+
+        return $response;
     }
 }


### PR DESCRIPTION
Also adjusted the `isSuccessful` method of `AuthorizeResponse` to always return `false`, since the authorization will never be completed nor successful at this point.