### PR TITLE
rename merchant_id to username

### DIFF
--- a/src/AuthenticationRequestOptionProvider.php
+++ b/src/AuthenticationRequestOptionProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace MyOnlineStore\Omnipay\KlarnaCheckout;
+
+use MyOnlineStore\Omnipay\KlarnaCheckout\Message\AbstractRequest;
+
+final class AuthenticationRequestOptionProvider
+{
+    /**
+     * @todo fallback to getMerchantId can be removed in next major version
+     *
+     * @param AbstractRequest $request
+     *
+     * @return array
+     */
+    public function getOptions(AbstractRequest $request)
+    {
+        return [
+            'auth' => [
+                !empty($request->getMerchantId()) ? $request->getMerchantId() : $request->getUsername(),
+                $request->getSecret(),
+            ],
+        ];
+    }
+}

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -71,15 +71,8 @@ final class Gateway extends AbstractGateway implements GatewayInterface
             'merchant_id' => '',
             'secret' => '',
             'testMode' => true,
+            'username' => '',
         ];
-    }
-
-    /**
-     * @return string
-     */
-    public function getMerchantId()
-    {
-        return $this->getParameter('merchant_id');
     }
 
     /**
@@ -99,9 +92,17 @@ final class Gateway extends AbstractGateway implements GatewayInterface
     }
 
     /**
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->getParameter('username');
+    }
+
+    /**
      * @inheritDoc
      */
-    public function initialize(array $parameters = array())
+    public function initialize(array $parameters = [])
     {
         parent::initialize($parameters);
 
@@ -115,15 +116,11 @@ final class Gateway extends AbstractGateway implements GatewayInterface
     }
 
     /**
-     * @param string $merchantId
-     *
-     * @return $this
+     * @inheritdoc
      */
-    public function setMerchantId($merchantId)
+    public function refund(array $options = [])
     {
-        $this->setParameter('merchant_id', $merchantId);
-
-        return $this;
+        return $this->createRequest(RefundRequest::class, $options);
     }
 
     /**
@@ -134,6 +131,20 @@ final class Gateway extends AbstractGateway implements GatewayInterface
     public function setApiRegion($region)
     {
         $this->setParameter('api_region', $region);
+
+        return $this;
+    }
+
+    /**
+     * @deprecated use setUsername instead
+     *
+     * @param string $merchantId
+     *
+     * @return $this
+     */
+    public function setMerchantId($merchantId)
+    {
+        $this->setParameter('merchant_id', $merchantId);
 
         return $this;
     }
@@ -151,11 +162,15 @@ final class Gateway extends AbstractGateway implements GatewayInterface
     }
 
     /**
-     * @inheritdoc
+     * @param string $username
+     *
+     * @return $this
      */
-    public function refund(array $options = [])
+    public function setUsername($username)
     {
-        return $this->createRequest(RefundRequest::class, $options);
+        $this->setParameter('username', $username);
+
+        return $this;
     }
 
     /**

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -76,6 +76,16 @@ final class Gateway extends AbstractGateway implements GatewayInterface
     }
 
     /**
+     * @deprecated use getUsername instead
+     *
+     * @return string
+     */
+    public function getMerchantId()
+    {
+        return $this->getParameter('merchant_id');
+    }
+
+    /**
      * @inheritDoc
      */
     public function getName()

--- a/tests/AuthenticationRequestOptionProviderTest.php
+++ b/tests/AuthenticationRequestOptionProviderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace MyOnlineStore\Tests\Omnipay\KlarnaCheckout;
+
+use MyOnlineStore\Omnipay\KlarnaCheckout\AuthenticationRequestOptionProvider;
+use MyOnlineStore\Omnipay\KlarnaCheckout\Message\AbstractRequest;
+
+final class AuthenticationRequestOptionProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWithMerchantIdSetWillReturnOptionsWithMerchantId()
+    {
+        $request = $this->getMockBuilder(AbstractRequest::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $request->expects(self::exactly(2))->method('getMerchantId')->will(self::returnValue('foobar'));
+        $request->expects(self::once())->method('getSecret')->will(self::returnValue('barbaz'));
+
+        self::assertEquals(
+            ['auth' => ['foobar', 'barbaz']],
+            (new AuthenticationRequestOptionProvider())->getOptions($request)
+        );
+    }
+
+    public function testWithNoMerchantIdSetWillReturnOptionsWithUsername()
+    {
+        $request = $this->getMockBuilder(AbstractRequest::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $request->expects(self::once())->method('getMerchantId')->will(self::returnValue(null));
+        $request->expects(self::once())->method('getUsername')->will(self::returnValue('foobar'));
+        $request->expects(self::once())->method('getSecret')->will(self::returnValue('barbaz'));
+
+        self::assertEquals(
+            ['auth' => ['foobar', 'barbaz']],
+            (new AuthenticationRequestOptionProvider())->getOptions($request)
+        );
+    }
+}

--- a/tests/Message/AcknowledgeRequestTest.php
+++ b/tests/Message/AcknowledgeRequestTest.php
@@ -41,7 +41,7 @@ class AcknowledgeRequestTest extends RequestTestCase
 
         $this->acknowledgeRequest->initialize([
             'base_url' => self::BASE_URL,
-            'merchant_id' => self::MERCHANT_ID,
+            'username' => self::USERNAME,
             'secret' => self::SECRET,
             'transactionReference' => 'foo',
         ]);

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -304,7 +304,7 @@ class AuthorizeRequestTest extends RequestTestCase
         $this->authorizeRequest->initialize(
             [
                 'base_url' => self::BASE_URL,
-                'merchant_id' => self::MERCHANT_ID,
+                'username' => self::USERNAME,
                 'secret' => self::SECRET,
             ]
         );
@@ -332,7 +332,7 @@ class AuthorizeRequestTest extends RequestTestCase
         $this->authorizeRequest->initialize(
             [
                 'base_url' => self::BASE_URL,
-                'merchant_id' => self::MERCHANT_ID,
+                'username' => self::USERNAME,
                 'secret' => self::SECRET,
                 'transactionReference' => 'f60e69e8-464a-48c0-a452-6fd562540f37',
             ]

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -98,7 +98,7 @@ class CaptureRequestTest extends RequestTestCase
                 self::BASE_URL.'/ordermanagement/v1/orders/'.self::TRANSACTION_REF.'/captures',
                 ['Content-Type' => 'application/json'],
                 json_encode($inputData),
-                ['auth' => [self::MERCHANT_ID, self::SECRET]]
+                ['auth' => [self::USERNAME, self::SECRET]]
             )->andReturn($request);
 
         $this->setExpectedGetRequest(
@@ -108,7 +108,7 @@ class CaptureRequestTest extends RequestTestCase
 
         $this->captureRequest->initialize([
             'base_url' => self::BASE_URL,
-            'merchant_id' => self::MERCHANT_ID,
+            'username' => self::USERNAME,
             'secret' => self::SECRET,
             'transactionReference' => self::TRANSACTION_REF,
         ]);

--- a/tests/Message/FetchTransactionRequestTest.php
+++ b/tests/Message/FetchTransactionRequestTest.php
@@ -44,7 +44,7 @@ class FetchTransactionRequestTest extends RequestTestCase
 
         $this->fetchTransactionRequest->initialize([
             'base_url' => self::BASE_URL,
-            'merchant_id' => self::MERCHANT_ID,
+            'username' => self::USERNAME,
             'secret' => self::SECRET,
             'transactionReference' => 'foo',
         ]);
@@ -62,7 +62,7 @@ class FetchTransactionRequestTest extends RequestTestCase
 
         $this->fetchTransactionRequest->initialize([
             'base_url' => self::BASE_URL,
-            'merchant_id' => self::MERCHANT_ID,
+            'username' => self::USERNAME,
             'secret' => self::SECRET,
             'transactionReference' => 'foo',
         ]);
@@ -83,7 +83,7 @@ class FetchTransactionRequestTest extends RequestTestCase
 
         $this->fetchTransactionRequest->initialize([
             'base_url' => self::BASE_URL,
-            'merchant_id' => self::MERCHANT_ID,
+            'username' => self::USERNAME,
             'secret' => self::SECRET,
             'transactionReference' => 'foo',
         ]);

--- a/tests/Message/RefundRequestTest.php
+++ b/tests/Message/RefundRequestTest.php
@@ -89,7 +89,7 @@ class RefundRequestTest extends RequestTestCase
 
         $this->refundRequest->initialize([
             'base_url' => self::BASE_URL,
-            'merchant_id' => self::MERCHANT_ID,
+            'username' => self::USERNAME,
             'secret' => self::SECRET,
             'transactionReference' => 'foo',
         ]);

--- a/tests/Message/RequestTestCase.php
+++ b/tests/Message/RequestTestCase.php
@@ -11,7 +11,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 abstract class RequestTestCase extends TestCase
 {
     const BASE_URL = 'http://localhost';
-    const MERCHANT_ID = 'merchant-32';
+    const USERNAME = 'merchant-32';
     const SECRET = 'very-secret-stuff';
 
     /**
@@ -102,7 +102,7 @@ abstract class RequestTestCase extends TestCase
                 $url,
                 $headers,
                 json_encode($inputData),
-                ['auth' => [self::MERCHANT_ID, self::SECRET]]
+                ['auth' => [self::USERNAME, self::SECRET]]
             )->andReturn($request);
 
         return $response;

--- a/tests/Message/UpdateTransactionRequestTest.php
+++ b/tests/Message/UpdateTransactionRequestTest.php
@@ -251,7 +251,7 @@ class UpdateTransactionRequestTest extends RequestTestCase
         $this->updateTransactionRequest->initialize(
             [
                 'base_url' => self::BASE_URL,
-                'merchant_id' => self::MERCHANT_ID,
+                'username' => self::USERNAME,
                 'secret' => self::SECRET,
                 'transactionReference' => self::TRANSACTION_REFERENCE,
             ]
@@ -289,7 +289,7 @@ class UpdateTransactionRequestTest extends RequestTestCase
 
         $this->updateTransactionRequest->initialize([
             'base_url' => self::BASE_URL,
-            'merchant_id' => self::MERCHANT_ID,
+            'username' => self::USERNAME,
             'secret' => self::SECRET,
             'transactionReference' => self::TRANSACTION_REFERENCE,
         ]);
@@ -317,7 +317,7 @@ class UpdateTransactionRequestTest extends RequestTestCase
 
         $this->updateTransactionRequest->initialize([
             'base_url' => self::BASE_URL,
-            'merchant_id' => self::MERCHANT_ID,
+            'username' => self::USERNAME,
             'secret' => self::SECRET,
             'transactionReference' => self::TRANSACTION_REFERENCE,
         ]);

--- a/tests/Message/VoidRequestTest.php
+++ b/tests/Message/VoidRequestTest.php
@@ -74,7 +74,7 @@ class VoidRequestTest extends RequestTestCase
 
         $this->voidRequest->initialize([
             'base_url' => self::BASE_URL,
-            'merchant_id' => self::MERCHANT_ID,
+            'username' => self::USERNAME,
             'secret' => self::SECRET,
             'transactionReference' => self::TRANSACTION_REF,
         ]);


### PR DESCRIPTION
the term merchant_id is misleading, Klarna issue a merchant_id and username to a merchant, where the username (the merchant_id with a random string) should be used to authenticate against the apis

see: https://developers.klarna.com/api/#authentication