### PR TITLE
added missing response data of ExtendAuthorization requests

### DIFF
--- a/src/Message/ExtendAuthorizationRequest.php
+++ b/src/Message/ExtendAuthorizationRequest.php
@@ -27,7 +27,7 @@ final class ExtendAuthorizationRequest extends AbstractRequest
      */
     public function sendData($data)
     {
-        $this->getResponseBody(
+        $responseBody = $this->getResponseBody(
             $this->sendRequest(
                 RequestInterface::POST,
                 sprintf('/ordermanagement/v1/orders/%s/extend-authorization-time', $this->getTransactionReference()),
@@ -35,6 +35,12 @@ final class ExtendAuthorizationRequest extends AbstractRequest
             )
         );
 
-        return new ExtendAuthorizationResponse($this, ['order_id' => $this->getTransactionReference()]);
+        return new ExtendAuthorizationResponse(
+            $this,
+            \array_merge(
+                $responseBody,
+                ['order_id' => $this->getTransactionReference()]
+            )
+        );
     }
 }

--- a/tests/Message/ExtendAuthorizationRequestTest.php
+++ b/tests/Message/ExtendAuthorizationRequestTest.php
@@ -41,7 +41,7 @@ final class ExtendAuthorizationRequestTest extends RequestTestCase
     {
         $this->setExpectedPostRequest(
             [],
-            [],
+            ['hello' => 'world'],
             sprintf(
                 '%s/ordermanagement/v1/orders/%s/extend-authorization-time',
                 self::BASE_URL,
@@ -62,5 +62,12 @@ final class ExtendAuthorizationRequestTest extends RequestTestCase
 
         self::assertInstanceOf(ExtendAuthorizationResponse::class, $extendAuthorizationResponse);
         self::assertSame('foo', $extendAuthorizationResponse->getTransactionReference());
+        self::assertSame(
+            [
+                'hello' => 'world',
+                'order_id' => 'foo',
+            ],
+            $extendAuthorizationResponse->getData()
+        );
     }
 }


### PR DESCRIPTION
Response data wasn't injected properly within the `ExtendAuthorizationResponse`, causing falsy results for `isSuccessful` calls. 