### PR TITLE
Added purchase country as parameter

### DIFF
--- a/src/Message/AbstractOrderRequest.php
+++ b/src/Message/AbstractOrderRequest.php
@@ -35,6 +35,14 @@ abstract class AbstractOrderRequest extends AbstractRequest
     }
 
     /**
+     * @return bool
+     */
+    public function getPurchaseCountry()
+    {
+        return $this->getParameter('purchase_country');
+    }
+
+    /**
      * @return Address
      */
     public function getShippingAddress()
@@ -115,6 +123,18 @@ abstract class AbstractOrderRequest extends AbstractRequest
     }
 
     /**
+     * @param bool $value
+     *
+     * @return $this
+     */
+    public function setPurchaseCountry($value)
+    {
+        $this->setParameter('purchase_country', $value);
+
+        return $this;
+    }
+
+    /**
      * @param string[] $countries ISO 3166 alpha-2 codes of shipping countries
      *
      * @return $this
@@ -160,11 +180,11 @@ abstract class AbstractOrderRequest extends AbstractRequest
             'order_tax_amount' => $this->toCurrencyMinorUnits($this->getTaxAmount()),
             'order_lines' => $this->getItemData($this->getItems()),
             'purchase_currency' => $this->getCurrency(),
+            'purchase_country' => $this->getPurchaseCountry(),
         ];
 
         if (null !== $locale = $this->getLocale()) {
             $data['locale'] = str_replace('_', '-', $locale);
-            $data['purchase_country'] = explode('_', $locale)[1];
         }
 
         if (null !== $shippingCountries = $this->getShippingCountries()) {

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -37,6 +37,7 @@ final class AuthorizeRequest extends AbstractOrderRequest
             'items',
             'locale',
             'notifyUrl',
+            'purchase_country',
             'returnUrl',
             'tax_amount',
             'termsUrl',

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -38,6 +38,7 @@ class AuthorizeRequestTest extends RequestTestCase
             'items' => [],
             'locale' => true,
             'notifyUrl' => true,
+            'purchase_country' => true,
             'returnUrl' => true,
             'tax_amount' => true,
             'terms_url' => true,
@@ -79,6 +80,7 @@ class AuthorizeRequestTest extends RequestTestCase
                 'termsUrl' => 'localhost/terms',
                 'currency' => 'EUR',
                 'validationUrl' => 'localhost/validate',
+                'purchase_country' => 'NL',
             ]
         );
         $this->authorizeRequest->setItems([$this->getItemMock()]);
@@ -164,6 +166,7 @@ class AuthorizeRequestTest extends RequestTestCase
                 'termsUrl' => 'localhost/terms',
                 'currency' => 'EUR',
                 'validationUrl' => 'localhost/validate',
+                'purchase_country' => 'DE',
             ]
         );
         $this->authorizeRequest->setItems([$this->getItemMock()]);
@@ -184,7 +187,7 @@ class AuthorizeRequestTest extends RequestTestCase
                     'terms' => 'localhost/terms',
                     'validation' => 'localhost/validate',
                 ],
-                'purchase_country' => 'NL',
+                'purchase_country' => 'DE',
                 'purchase_currency' => 'EUR',
                 'shipping_address' => $shippingAddress,
                 'billing_address' => $billingAddress,
@@ -228,6 +231,7 @@ class AuthorizeRequestTest extends RequestTestCase
                 'currency' => 'EUR',
                 'validationUrl' => 'localhost/validate',
                 'shipping_countries' => ['NL', 'DE'],
+                'purchase_country' => 'BE',
             ]
         );
         $this->authorizeRequest->setItems([$this->getItemMock()]);
@@ -246,7 +250,7 @@ class AuthorizeRequestTest extends RequestTestCase
                     'terms' => 'localhost/terms',
                     'validation' => 'localhost/validate',
                 ],
-                'purchase_country' => 'NL',
+                'purchase_country' => 'BE',
                 'purchase_currency' => 'EUR',
                 'options' => $widgetOptions,
                 'shipping_countries' => ['NL', 'DE'],
@@ -273,6 +277,7 @@ class AuthorizeRequestTest extends RequestTestCase
                 'termsUrl' => 'localhost/terms',
                 'currency' => 'EUR',
                 'validationUrl' => 'localhost/validate',
+                'purchase_country' => 'FR',
             ]
         );
         $this->authorizeRequest->setCustomer($customer);
@@ -292,7 +297,7 @@ class AuthorizeRequestTest extends RequestTestCase
                     'terms' => 'localhost/terms',
                     'validation' => 'localhost/validate',
                 ],
-                'purchase_country' => 'NL',
+                'purchase_country' => 'FR',
                 'purchase_currency' => 'EUR',
                 'customer' => $customer,
             ],

--- a/tests/Message/UpdateTransactionRequestTest.php
+++ b/tests/Message/UpdateTransactionRequestTest.php
@@ -46,6 +46,7 @@ class UpdateTransactionRequestTest extends RequestTestCase
                 'gui_autofocus' => false,
                 'merchant_reference1' => '12345',
                 'merchant_reference2' => 678,
+                'purchase_country' => 'FR',
             ]
         );
         $this->updateTransactionRequest->setItems([$this->getItemMock()]);
@@ -59,6 +60,7 @@ class UpdateTransactionRequestTest extends RequestTestCase
                 'gui' => ['options' => ['disable_autofocus', 'minimal_confirmation']],
                 'merchant_reference1' => '12345',
                 'merchant_reference2' => 678,
+                'purchase_country' => 'FR',
             ],
             $this->updateTransactionRequest->getData()
         );
@@ -123,6 +125,7 @@ class UpdateTransactionRequestTest extends RequestTestCase
                 'gui_autofocus' => false,
                 'merchant_reference1' => '12345',
                 'merchant_reference2' => 678,
+                'purchase_country' => 'NL',
             ]
         );
         $this->updateTransactionRequest->setItems([$this->getItemMock()]);
@@ -182,6 +185,7 @@ class UpdateTransactionRequestTest extends RequestTestCase
                 'gui_autofocus' => false,
                 'merchant_reference1' => '12345',
                 'merchant_reference2' => 678,
+                'purchase_country' => 'DE',
             ]
         );
         $this->updateTransactionRequest->setItems([$this->getItemMock()]);
@@ -193,7 +197,7 @@ class UpdateTransactionRequestTest extends RequestTestCase
                 'order_amount' => 10000,
                 'order_tax_amount' => 2100,
                 'order_lines' => [$this->getExpectedOrderLine()],
-                'purchase_country' => 'NL',
+                'purchase_country' => 'DE',
                 'purchase_currency' => 'EUR',
                 'gui' => ['options' => ['disable_autofocus', 'minimal_confirmation']],
                 'merchant_reference1' => '12345',
@@ -218,6 +222,7 @@ class UpdateTransactionRequestTest extends RequestTestCase
                 'tax_amount' => 21,
                 'currency' => 'EUR',
                 'transactionReference' => self::TRANSACTION_REFERENCE,
+                'purchase_country' => 'FR',
             ]
         );
         $this->updateTransactionRequest->setItems([$this->getItemMock()]);
@@ -229,7 +234,7 @@ class UpdateTransactionRequestTest extends RequestTestCase
                 'order_amount' => 10000,
                 'order_tax_amount' => 2100,
                 'order_lines' => [$this->getExpectedOrderLine()],
-                'purchase_country' => 'NL',
+                'purchase_country' => 'FR',
                 'purchase_currency' => 'EUR',
                 'customer' => $customer,
             ],


### PR DESCRIPTION
Purchase country is a required parameter and should be specified explicitly, rather than derived from the locale