### PR TITLE
Fetch data from management api if order is deleted from the checkout api

### DIFF
--- a/src/Message/FetchTransactionRequest.php
+++ b/src/Message/FetchTransactionRequest.php
@@ -21,11 +21,17 @@ final class FetchTransactionRequest extends AbstractRequest
      */
     public function sendData($data)
     {
-        $responseData['checkout'] = $this->getResponseBody(
-            $this->sendRequest(RequestInterface::GET, '/checkout/v3/orders/'.$this->getTransactionReference(), $data)
+        $response = $this->sendRequest(
+            RequestInterface::GET,
+            '/checkout/v3/orders/'.$this->getTransactionReference(),
+            $data
         );
 
-        if (isset($responseData['checkout']['status']) && 'checkout_complete' === $responseData['checkout']['status']) {
+        $responseData['checkout'] = $this->getResponseBody($response);
+
+        if (404 === $response->getStatusCode() ||
+            (isset($responseData['checkout']['status']) && 'checkout_complete' === $responseData['checkout']['status'])
+        ) {
             $responseData['management'] = $this->getResponseBody(
                 $this->sendRequest(
                     RequestInterface::GET,


### PR DESCRIPTION
- [x] Verify with Klarna contact this is a valid occurance

Confirmed, requests on the Checkout API may return a 404, while the OrderManagement Api would return a 200 response for the same order ID