### PR TITLE
Read order_id from management transaction if no checkout data available

### DIFF
--- a/src/Message/FetchTransactionResponse.php
+++ b/src/Message/FetchTransactionResponse.php
@@ -9,7 +9,9 @@ final class FetchTransactionResponse extends AbstractResponse
      */
     public function getTransactionReference()
     {
-        return $this->data['checkout']['order_id'];
+        return isset($this->data['checkout']['order_id']) ?
+            $this->data['checkout']['order_id'] :
+            $this->data['management']['order_id'];
     }
 
     /**

--- a/tests/Message/FetchTransactionResponseTest.php
+++ b/tests/Message/FetchTransactionResponseTest.php
@@ -21,12 +21,20 @@ class FetchTransactionResponseTest extends TestCase
         ];
     }
 
-    public function testGetters()
+    public function testGetTransactionReferenceForCheckoutTransaction()
     {
         $responseData = ['checkout' => ['order_id' => 'foo']];
         $response = new FetchTransactionResponse($this->getMockRequest(), $responseData);
 
         self::assertSame($responseData['checkout']['order_id'], $response->getTransactionReference());
+    }
+
+    public function testGetTransactionReferenceForManagementTransaction()
+    {
+        $responseData = ['management' => ['order_id' => 'foo']];
+        $response = new FetchTransactionResponse($this->getMockRequest(), $responseData);
+
+        self::assertSame($responseData['management']['order_id'], $response->getTransactionReference());
     }
 
     /**


### PR DESCRIPTION
Missed this while reviewing #32: transaction reference should also be available from management data