### PR TITLE
get status codes for capture, void and refund requests and adjust isSucccesful check accordingly

### DIFF
--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -2,14 +2,19 @@
 
 namespace MyOnlineStore\Omnipay\KlarnaCheckout\Message;
 
+use Guzzle\Common\Exception\InvalidArgumentException;
+use Guzzle\Http\Exception\RequestException;
 use Guzzle\Http\Message\RequestInterface;
+use Omnipay\Common\Exception\InvalidRequestException;
 
 final class CaptureRequest extends AbstractRequest
 {
     use ItemDataTrait;
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
+     *
+     * @throws InvalidRequestException
      */
     public function getData()
     {
@@ -25,24 +30,27 @@ final class CaptureRequest extends AbstractRequest
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
+     *
+     * @throws RequestException
+     * @throws InvalidArgumentException
      */
     public function sendData($data)
     {
-        $response = $this->sendRequest(RequestInterface::POST, $this->getEndpoint(), $data);
+        $response = $this->sendRequest(
+            RequestInterface::POST,
+            sprintf(
+                '/ordermanagement/v1/orders/%s/captures',
+                $this->getTransactionReference()
+            ),
+            $data
+        );
 
         return new CaptureResponse(
             $this,
             $this->getResponseBody($response),
-            $this->getTransactionReference()
+            $this->getTransactionReference(),
+            $response->getStatusCode()
         );
-    }
-
-    /**
-     * @inheritdoc
-     */
-    private function getEndpoint()
-    {
-        return '/ordermanagement/v1/orders/'.$this->getTransactionReference().'/captures';
     }
 }

--- a/src/Message/CaptureResponse.php
+++ b/src/Message/CaptureResponse.php
@@ -7,6 +7,11 @@ use Omnipay\Common\Message\RequestInterface;
 final class CaptureResponse extends AbstractResponse
 {
     /**
+     * @var int
+     */
+    private $statusCode;
+
+    /**
      * @var string
      */
     private $transactionReference;
@@ -15,12 +20,22 @@ final class CaptureResponse extends AbstractResponse
      * @param RequestInterface $request
      * @param mixed            $data
      * @param string           $transactionReference
+     * @param int              $statusCode
      */
-    public function __construct(RequestInterface $request, $data, $transactionReference)
+    public function __construct(RequestInterface $request, $data, $transactionReference, $statusCode)
     {
         parent::__construct($request, $data);
 
         $this->transactionReference = $transactionReference;
+        $this->statusCode = $statusCode;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
     }
 
     /**
@@ -29,5 +44,13 @@ final class CaptureResponse extends AbstractResponse
     public function getTransactionReference()
     {
         return $this->transactionReference;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isSuccessful()
+    {
+        return parent::isSuccessful() && 201 === $this->statusCode;
     }
 }

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -2,7 +2,10 @@
 
 namespace MyOnlineStore\Omnipay\KlarnaCheckout\Message;
 
+use Guzzle\Common\Exception\InvalidArgumentException;
+use Guzzle\Http\Exception\RequestException;
 use Guzzle\Http\Message\RequestInterface;
+use Omnipay\Common\Exception\InvalidRequestException;
 
 final class RefundRequest extends AbstractRequest
 {
@@ -10,6 +13,8 @@ final class RefundRequest extends AbstractRequest
 
     /**
      * @inheritDoc
+     *
+     * @throws InvalidRequestException
      */
     public function getData()
     {
@@ -25,15 +30,23 @@ final class RefundRequest extends AbstractRequest
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
+     *
+     * @throws RequestException
+     * @throws InvalidArgumentException
      */
     public function sendData($data)
     {
-        $url = '/ordermanagement/v1/orders/'.$this->getTransactionReference().'/refunds';
+        $response = $this->sendRequest(
+            RequestInterface::POST,
+            sprintf('/ordermanagement/v1/orders/%s/refunds', $this->getTransactionReference()),
+            $data
+        );
 
         return new RefundResponse(
             $this,
-            $this->getResponseBody($this->sendRequest(RequestInterface::POST, $url, $data))
+            $this->getResponseBody($response),
+            $response->getStatusCode()
         );
     }
 }

--- a/src/Message/RefundResponse.php
+++ b/src/Message/RefundResponse.php
@@ -2,6 +2,40 @@
 
 namespace MyOnlineStore\Omnipay\KlarnaCheckout\Message;
 
+use Omnipay\Common\Message\RequestInterface;
+
 final class RefundResponse extends AbstractResponse
 {
+    /**
+     * @var int
+     */
+    private $statusCode;
+
+    /**
+     * @param RequestInterface $request
+     * @param mixed            $data
+     * @param int              $statusCode
+     */
+    public function __construct(RequestInterface $request, $data, $statusCode)
+    {
+        parent::__construct($request, $data);
+
+        $this->statusCode = $statusCode;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isSuccessful()
+    {
+        return parent::isSuccessful() && 201 === $this->statusCode;
+    }
 }

--- a/src/Message/VoidRequest.php
+++ b/src/Message/VoidRequest.php
@@ -2,12 +2,17 @@
 
 namespace MyOnlineStore\Omnipay\KlarnaCheckout\Message;
 
+use Guzzle\Common\Exception\InvalidArgumentException;
+use Guzzle\Http\Exception\RequestException;
 use Guzzle\Http\Message\RequestInterface;
+use Omnipay\Common\Exception\InvalidRequestException;
 
 final class VoidRequest extends AbstractRequest
 {
     /**
-     * @inheritDoc
+     * {@inheritDoc}
+     *
+     * @throws InvalidRequestException
      */
     public function getData()
     {
@@ -17,19 +22,30 @@ final class VoidRequest extends AbstractRequest
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
+     *
+     * @throws RequestException
+     * @throws InvalidArgumentException
      */
     public function sendData($data)
     {
-        $baseUrl = '/ordermanagement/v1/orders/'.$this->getTransactionReference();
+        $baseUrl = sprintf('/ordermanagement/v1/orders/%s', $this->getTransactionReference());
+        $orderManagementResponse = $this->sendRequest(RequestInterface::GET, $baseUrl, []);
 
-        $order = $this->getResponseBody($this->sendRequest(RequestInterface::GET, $baseUrl, []));
+        $order = $this->getResponseBody($orderManagementResponse);
 
-        $voidUrl = $baseUrl.(empty($order['captures']) ? '/cancel' : '/release-remaining-authorization');
+        $voidUrl = sprintf('%s/release-remaining-authorization', $baseUrl);
+
+        if (empty($order['captures'])) {
+            $voidUrl = sprintf('%s/cancel', $baseUrl);
+        }
+
+        $response = $this->sendRequest(RequestInterface::POST, $voidUrl, $data);
 
         return new VoidResponse(
             $this,
-            $this->getResponseBody($this->sendRequest(RequestInterface::POST, $voidUrl, $data))
+            $this->getResponseBody($response),
+            $response->getStatusCode()
         );
     }
 }

--- a/src/Message/VoidResponse.php
+++ b/src/Message/VoidResponse.php
@@ -2,6 +2,40 @@
 
 namespace MyOnlineStore\Omnipay\KlarnaCheckout\Message;
 
+use Omnipay\Common\Message\RequestInterface;
+
 final class VoidResponse extends AbstractResponse
 {
+    /**
+     * @var int
+     */
+    private $statusCode;
+
+    /**
+     * @param RequestInterface $request
+     * @param mixed            $data
+     * @param int              $statusCode
+     */
+    public function __construct(RequestInterface $request, $data, $statusCode)
+    {
+        parent::__construct($request, $data);
+
+        $this->statusCode = $statusCode;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isSuccessful()
+    {
+        return parent::isSuccessful() && 204 === $this->statusCode;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
 }

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -2,8 +2,6 @@
 
 namespace MyOnlineStore\Tests\Omnipay\KlarnaCheckout\Message;
 
-use Guzzle\Http\Message\RequestInterface;
-use Guzzle\Http\Message\Response;
 use MyOnlineStore\Omnipay\KlarnaCheckout\Message\CaptureRequest;
 use MyOnlineStore\Omnipay\KlarnaCheckout\Message\CaptureResponse;
 use Omnipay\Common\Exception\InvalidRequestException;
@@ -50,6 +48,8 @@ class CaptureRequestTest extends RequestTestCase
         $this->captureRequest->initialize($requestData);
 
         $this->setExpectedException(InvalidRequestException::class);
+
+        /** @noinspection PhpUnhandledExceptionInspection */
         $this->captureRequest->getData();
     }
 
@@ -75,6 +75,7 @@ class CaptureRequestTest extends RequestTestCase
         $this->captureRequest->initialize(['transactionReference' => self::TRANSACTION_REF, 'amount' => '10.00']);
         $this->captureRequest->setItems($items);
 
+        /** @noinspection PhpUnhandledExceptionInspection */
         self::assertEquals(
             ['captured_amount' => 1000] + $expectedItemData,
             $this->captureRequest->getData()
@@ -86,11 +87,12 @@ class CaptureRequestTest extends RequestTestCase
         $requestdata = ['request-data' => 'yey?'];
         $responseData = ['response-data' => 'yey!'];
 
-        $this->setExpectedPostRequest(
+        $response = $this->setExpectedPostRequest(
             $requestdata,
             $responseData,
             self::BASE_URL.'/ordermanagement/v1/orders/'.self::TRANSACTION_REF.'/captures'
         );
+        $response->shouldReceive('getStatusCode')->andReturn(204);
 
         $this->captureRequest->initialize([
             'base_url' => self::BASE_URL,

--- a/tests/Message/RefundRequestTest.php
+++ b/tests/Message/RefundRequestTest.php
@@ -45,6 +45,8 @@ class RefundRequestTest extends RequestTestCase
         $this->refundRequest->initialize($requestData);
 
         $this->setExpectedException(InvalidRequestException::class);
+
+        /** @noinspection PhpUnhandledExceptionInspection */
         $this->refundRequest->getData();
     }
 
@@ -70,6 +72,7 @@ class RefundRequestTest extends RequestTestCase
         $this->refundRequest->initialize(['transactionReference' => 'foo', 'amount' => '10.00']);
         $this->refundRequest->setItems($items);
 
+        /** @noinspection PhpUnhandledExceptionInspection */
         self::assertEquals(
             ['refunded_amount' => 1000] + $expectedItemData,
             $this->refundRequest->getData()
@@ -81,11 +84,13 @@ class RefundRequestTest extends RequestTestCase
         $inputData = ['request-data' => 'yey?'];
         $expectedData = [];
 
-        $this->setExpectedPostRequest(
+        $response = $this->setExpectedPostRequest(
             $inputData,
             $expectedData,
             self::BASE_URL.'/ordermanagement/v1/orders/foo/refunds'
         );
+
+        $response->shouldReceive('getStatusCode')->andReturn(204);
 
         $this->refundRequest->initialize([
             'base_url' => self::BASE_URL,

--- a/tests/Message/RefundResponseTest.php
+++ b/tests/Message/RefundResponseTest.php
@@ -2,16 +2,16 @@
 
 namespace MyOnlineStore\Tests\Omnipay\KlarnaCheckout\Message;
 
-use MyOnlineStore\Omnipay\KlarnaCheckout\Message\CaptureResponse;
+use MyOnlineStore\Omnipay\KlarnaCheckout\Message\RefundResponse;
 use Omnipay\Common\Message\RequestInterface;
 use Omnipay\Tests\TestCase;
 
-final class CaptureResponseTest extends TestCase
+final class RefundResponseTest extends TestCase
 {
     /**
      * All possible Klarna response codes for this class
      *
-     * @see https://developers.klarna.com/api/#order-management-api-create-capture
+     * @see https://developers.klarna.com/api/#order-management-api-refund
      *
      * @return array
      */
@@ -20,13 +20,12 @@ final class CaptureResponseTest extends TestCase
         return [[201, true], [403, false], [404, false]];
     }
 
-    public function testGetTransactionReferenceReturnsIdFromOrder()
+    public function testGetCommonValuesReturnCorrectValues()
     {
         $request = $this->getMock(RequestInterface::class);
 
-        $response = new CaptureResponse($request, [], 'foo', 201);
+        $response = new RefundResponse($request, [], 201);
 
-        self::assertSame('foo', $response->getTransactionReference());
         self::assertSame(201, $response->getStatusCode());
     }
 
@@ -40,7 +39,7 @@ final class CaptureResponseTest extends TestCase
     {
         $request = $this->getMock(RequestInterface::class);
 
-        $captureResponse = new CaptureResponse($request, [], '123', $responseCode);
+        $captureResponse = new RefundResponse($request, [], $responseCode);
 
         self::assertEquals($expectedResult, $captureResponse->isSuccessful());
     }

--- a/tests/Message/VoidRequestTest.php
+++ b/tests/Message/VoidRequestTest.php
@@ -29,6 +29,7 @@ class VoidRequestTest extends RequestTestCase
         $this->voidRequest->initialize([]);
 
         $this->setExpectedException(InvalidRequestException::class);
+        /** @noinspection PhpUnhandledExceptionInspection */
         $this->voidRequest->getData();
     }
 
@@ -36,6 +37,7 @@ class VoidRequestTest extends RequestTestCase
     {
         $this->voidRequest->initialize(['transactionReference' => 'foo']);
 
+        /** @noinspection PhpUnhandledExceptionInspection */
         self::assertEquals([], $this->voidRequest->getData());
     }
 
@@ -66,11 +68,12 @@ class VoidRequestTest extends RequestTestCase
             self::BASE_URL.'/ordermanagement/v1/orders/'.self::TRANSACTION_REF
         );
 
-        $this->setExpectedPostRequest(
+        $response = $this->setExpectedPostRequest(
             $inputData,
             $expectedData,
             self::BASE_URL.'/ordermanagement/v1/orders/'.self::TRANSACTION_REF.$expectedPostRoute
         );
+        $response->shouldReceive('getStatusCode')->andReturn(204);
 
         $this->voidRequest->initialize([
             'base_url' => self::BASE_URL,

--- a/tests/Message/VoidResponseTest.php
+++ b/tests/Message/VoidResponseTest.php
@@ -2,31 +2,30 @@
 
 namespace MyOnlineStore\Tests\Omnipay\KlarnaCheckout\Message;
 
-use MyOnlineStore\Omnipay\KlarnaCheckout\Message\CaptureResponse;
+use MyOnlineStore\Omnipay\KlarnaCheckout\Message\VoidResponse;
 use Omnipay\Common\Message\RequestInterface;
 use Omnipay\Tests\TestCase;
 
-final class CaptureResponseTest extends TestCase
+final class VoidResponseTest extends TestCase
 {
     /**
      * All possible Klarna response codes for this class
      *
-     * @see https://developers.klarna.com/api/#order-management-api-create-capture
+     * @see https://developers.klarna.com/api/#order-management-api-cancel-order
      *
      * @return array
      */
     public function responseCodeProvider()
     {
-        return [[201, true], [403, false], [404, false]];
+        return [[204, true], [403, false],];
     }
 
-    public function testGetTransactionReferenceReturnsIdFromOrder()
+    public function testGetCommonValuesReturnCorrectValues()
     {
         $request = $this->getMock(RequestInterface::class);
 
-        $response = new CaptureResponse($request, [], 'foo', 201);
+        $response = new VoidResponse($request, [], 201);
 
-        self::assertSame('foo', $response->getTransactionReference());
         self::assertSame(201, $response->getStatusCode());
     }
 
@@ -40,7 +39,7 @@ final class CaptureResponseTest extends TestCase
     {
         $request = $this->getMock(RequestInterface::class);
 
-        $captureResponse = new CaptureResponse($request, [], '123', $responseCode);
+        $captureResponse = new VoidResponse($request, [], $responseCode);
 
         self::assertEquals($expectedResult, $captureResponse->isSuccessful());
     }


### PR DESCRIPTION
take into account response status codes in Void/Refund/Capture responses when determining success state