### PR TITLE
Allow updates to merchant urls

### DIFF
--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -10,21 +10,7 @@ use Omnipay\Common\Exception\InvalidResponseException;
  */
 final class AuthorizeRequest extends AbstractOrderRequest
 {
-    /**
-     * @return string
-     */
-    public function getAddressUpdateUrl()
-    {
-        return $this->getParameter('addressUpdateUrl');
-    }
-
-    /**
-     * @return string
-     */
-    public function getCancellationTermsUrl()
-    {
-        return $this->getParameter('cancellationTermsUrl');
-    }
+    use MerchantUrlsDataTrait;
 
     /**
      * @inheritDoc
@@ -36,32 +22,12 @@ final class AuthorizeRequest extends AbstractOrderRequest
             'currency',
             'items',
             'locale',
-            'notifyUrl',
             'purchase_country',
-            'returnUrl',
-            'tax_amount',
-            'termsUrl',
-            'validationUrl'
+            'tax_amount'
         );
 
-        $merchantUrls = [
-            'checkout' => $this->getReturnUrl(),
-            'confirmation' => $this->getReturnUrl(),
-            'push' => $this->getNotifyUrl(),
-            'terms' => $this->getTermsUrl(),
-            'validation' => $this->getValidationUrl(),
-        ];
-
-        if (null !== ($cancellationTermsUrl = $this->getCancellationTermsUrl())) {
-            $merchantUrls['cancellation_terms'] = $cancellationTermsUrl;
-        }
-
-        if (null !== ($addressUpdateUrl = $this->getAddressUpdateUrl())) {
-            $merchantUrls['address_update'] = $addressUpdateUrl;
-        }
-
         $data = $this->getOrderData();
-        $data['merchant_urls'] = $merchantUrls;
+        $data['merchant_urls'] = $this->getMerchantUrls();
 
         return $data;
     }
@@ -72,22 +38,6 @@ final class AuthorizeRequest extends AbstractOrderRequest
     public function getRenderUrl()
     {
         return $this->getParameter('render_url');
-    }
-
-    /**
-     * @return string
-     */
-    public function getTermsUrl()
-    {
-        return $this->getParameter('termsUrl');
-    }
-
-    /**
-     * @return string
-     */
-    public function getValidationUrl()
-    {
-        return $this->getParameter('validationUrl');
     }
 
     /**
@@ -107,30 +57,6 @@ final class AuthorizeRequest extends AbstractOrderRequest
     }
 
     /**
-     * @param $url
-     *
-     * @return $this
-     */
-    public function setAddressUpdateUrl($url)
-    {
-        $this->setParameter('addressUpdateUrl', $url);
-
-        return $this;
-    }
-
-    /**
-     * @param string $url
-     *
-     * @return $this
-     */
-    public function setCancellationTermsUrl($url)
-    {
-        $this->setParameter('cancellationTermsUrl', $url);
-
-        return $this;
-    }
-
-    /**
      * @param string $url
      *
      * @return $this
@@ -138,30 +64,6 @@ final class AuthorizeRequest extends AbstractOrderRequest
     public function setRenderUrl($url)
     {
         $this->setParameter('render_url', $url);
-
-        return $this;
-    }
-
-    /**
-     * @param string $url
-     *
-     * @return $this
-     */
-    public function setTermsUrl($url)
-    {
-        $this->setParameter('termsUrl', $url);
-
-        return $this;
-    }
-
-    /**
-     * @param string $url
-     *
-     * @return $this
-     */
-    public function setValidationUrl($url)
-    {
-        $this->setParameter('validationUrl', $url);
 
         return $this;
     }

--- a/src/Message/MerchantUrlsDataTrait.php
+++ b/src/Message/MerchantUrlsDataTrait.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace MyOnlineStore\Omnipay\KlarnaCheckout\Message;
+
+use Omnipay\Common\Exception\InvalidRequestException;
+use Omnipay\Common\Exception\RuntimeException;
+
+trait MerchantUrlsDataTrait
+{
+    /**
+     * @return string
+     */
+    public function getAddressUpdateUrl()
+    {
+        return $this->getParameter('addressUpdateUrl');
+    }
+
+    /**
+     * @return string
+     */
+    public function getCancellationTermsUrl()
+    {
+        return $this->getParameter('cancellationTermsUrl');
+    }
+
+    /**
+     * @return array
+     *
+     * @throws InvalidRequestException
+     */
+    public function getMerchantUrls()
+    {
+        $this->validate('notifyUrl', 'returnUrl', 'termsUrl', 'validationUrl');
+
+        $merchantUrls = [
+            'checkout' => $this->getReturnUrl(),
+            'confirmation' => $this->getReturnUrl(),
+            'push' => $this->getNotifyUrl(),
+            'terms' => $this->getTermsUrl(),
+            'validation' => $this->getValidationUrl(),
+        ];
+
+        if (null !== ($cancellationTermsUrl = $this->getCancellationTermsUrl())) {
+            $merchantUrls['cancellation_terms'] = $cancellationTermsUrl;
+        }
+
+        if (null !== ($addressUpdateUrl = $this->getAddressUpdateUrl())) {
+            $merchantUrls['address_update'] = $addressUpdateUrl;
+        }
+
+        return $merchantUrls;
+    }
+
+    /**
+     * @return string
+     */
+    abstract public function getNotifyUrl();
+
+    /**
+     * @return string
+     */
+    abstract public function getReturnUrl();
+
+    /**
+     * @return string
+     */
+    public function getTermsUrl()
+    {
+        return $this->getParameter('termsUrl');
+    }
+
+    /**
+     * @return string
+     */
+    public function getValidationUrl()
+    {
+        return $this->getParameter('validationUrl');
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return $this
+     */
+    public function setAddressUpdateUrl($url)
+    {
+        $this->setParameter('addressUpdateUrl', $url);
+
+        return $this;
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return $this
+     */
+    public function setCancellationTermsUrl($url)
+    {
+        $this->setParameter('cancellationTermsUrl', $url);
+
+        return $this;
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return $this
+     */
+    public function setTermsUrl($url)
+    {
+        $this->setParameter('termsUrl', $url);
+
+        return $this;
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return $this
+     */
+    public function setValidationUrl($url)
+    {
+        $this->setParameter('validationUrl', $url);
+
+        return $this;
+    }
+    /**
+     * @param string ... a variable length list of required parameters
+     *
+     * @throws InvalidRequestException
+     */
+    abstract public function validate();
+
+    /**
+     * @param string $key
+     *
+     * @return mixed
+     */
+    abstract protected function getParameter($key);
+
+    /**
+     * Set a single parameter
+     *
+     * @param string $key   The parameter key
+     * @param mixed  $value The value to set
+     *
+     * @return AbstractRequest Provides a fluent interface
+     *
+     * @throws RuntimeException if a request parameter is modified after the request has been sent.
+     */
+    abstract protected function setParameter($key, $value);
+}

--- a/src/Message/UpdateTransactionRequest.php
+++ b/src/Message/UpdateTransactionRequest.php
@@ -3,23 +3,32 @@
 namespace MyOnlineStore\Omnipay\KlarnaCheckout\Message;
 
 use Guzzle\Http\Message\RequestInterface;
+use Omnipay\Common\Exception\InvalidRequestException;
 
 final class UpdateTransactionRequest extends AbstractOrderRequest
 {
     use ItemDataTrait;
+    use MerchantUrlsDataTrait;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     public function getData()
     {
         $this->validate('transactionReference');
+        $data = $this->getOrderData();
 
-        return $this->getOrderData();
+        try {
+            $data['merchant_urls'] = $this->getMerchantUrls();
+        } catch (InvalidRequestException $exception) {
+            // Insufficient data for merchant urls
+        }
+
+        return $data;
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     public function sendData($data)
     {

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -12,6 +12,7 @@ use Omnipay\Common\Exception\InvalidResponseException;
 class AuthorizeRequestTest extends RequestTestCase
 {
     use ItemDataTestTrait;
+    use MerchantUrlsDataTestTrait;
 
     /**
      * @var AuthorizeRequest
@@ -32,17 +33,17 @@ class AuthorizeRequestTest extends RequestTestCase
      */
     public function invalidRequestDataProvider()
     {
-        $data = [
-            'amount' => true,
-            'currency' => true,
-            'items' => [],
-            'locale' => true,
-            'notifyUrl' => true,
-            'purchase_country' => true,
-            'returnUrl' => true,
-            'tax_amount' => true,
-            'terms_url' => true,
-        ];
+        $data = array_merge(
+            [
+                'amount' => true,
+                'currency' => true,
+                'items' => [],
+                'locale' => true,
+                'purchase_country' => true,
+                'tax_amount' => true,
+            ],
+            array_fill_keys(array_keys($this->getMinimalValidMerchantUrlData()), true)
+        );
 
         $cases = [];
 
@@ -69,20 +70,18 @@ class AuthorizeRequestTest extends RequestTestCase
     public function testGetDataWillReturnCorrectData()
     {
         $this->authorizeRequest->initialize(
-            [
-                'locale' => 'nl_NL',
-                'addressUpdateUrl' => 'localhost/address-update',
-                'amount' => '100.00',
-                'cancellationTermsUrl' => 'localhost/cancellation-terms',
-                'tax_amount' => 21,
-                'returnUrl' => 'localhost/return',
-                'notifyUrl' => 'localhost/notify',
-                'termsUrl' => 'localhost/terms',
-                'currency' => 'EUR',
-                'validationUrl' => 'localhost/validate',
-                'purchase_country' => 'NL',
-            ]
+            array_merge(
+                [
+                    'locale' => 'nl_NL',
+                    'amount' => '100.00',
+                    'tax_amount' => 21,
+                    'currency' => 'EUR',
+                    'purchase_country' => 'NL',
+                ],
+                $this->getCompleteValidMerchantUrlData()
+            )
         );
+
         $this->authorizeRequest->setItems([$this->getItemMock()]);
 
         self::assertEquals(
@@ -91,15 +90,7 @@ class AuthorizeRequestTest extends RequestTestCase
                 'order_amount' => 10000,
                 'order_tax_amount' => 2100,
                 'order_lines' => [$this->getExpectedOrderLine()],
-                'merchant_urls' => [
-                    'address_update' => 'localhost/address-update',
-                    'cancellation_terms' => 'localhost/cancellation-terms',
-                    'checkout' => 'localhost/return',
-                    'confirmation' => 'localhost/return',
-                    'push' => 'localhost/notify',
-                    'terms' => 'localhost/terms',
-                    'validation' => 'localhost/validate',
-                ],
+                'merchant_urls' => $this->getCompleteExpectedMerchantUrlData(),
                 'purchase_country' => 'NL',
                 'purchase_currency' => 'EUR',
             ],
@@ -156,18 +147,16 @@ class AuthorizeRequestTest extends RequestTestCase
         ];
 
         $this->authorizeRequest->initialize(
-            [
-                'cancellationTermsUrl' => 'localhost/cancellation-terms',
-                'locale' => 'nl_NL',
-                'amount' => '100.00',
-                'tax_amount' => 21,
-                'returnUrl' => 'localhost/return',
-                'notifyUrl' => 'localhost/notify',
-                'termsUrl' => 'localhost/terms',
-                'currency' => 'EUR',
-                'validationUrl' => 'localhost/validate',
-                'purchase_country' => 'DE',
-            ]
+            array_merge(
+                [
+                    'locale' => 'nl_NL',
+                    'amount' => '100.00',
+                    'tax_amount' => 21,
+                    'currency' => 'EUR',
+                    'purchase_country' => 'DE',
+                ],
+                $this->getMinimalValidMerchantUrlData()
+            )
         );
         $this->authorizeRequest->setItems([$this->getItemMock()]);
         $this->authorizeRequest->setBillingAddress($billingAddress);
@@ -179,14 +168,7 @@ class AuthorizeRequestTest extends RequestTestCase
                 'order_amount' => 10000,
                 'order_tax_amount' => 2100,
                 'order_lines' => [$this->getExpectedOrderLine()],
-                'merchant_urls' => [
-                    'cancellation_terms' => 'localhost/cancellation-terms',
-                    'checkout' => 'localhost/return',
-                    'confirmation' => 'localhost/return',
-                    'push' => 'localhost/notify',
-                    'terms' => 'localhost/terms',
-                    'validation' => 'localhost/validate',
-                ],
+                'merchant_urls' => $this->getMinimalExpectedMerchantUrlData(),
                 'purchase_country' => 'DE',
                 'purchase_currency' => 'EUR',
                 'shipping_address' => $shippingAddress,
@@ -221,18 +203,17 @@ class AuthorizeRequestTest extends RequestTestCase
         ];
 
         $this->authorizeRequest->initialize(
-            [
-                'locale' => 'nl_NL',
-                'amount' => '100.00',
-                'tax_amount' => 21,
-                'returnUrl' => 'localhost/return',
-                'notifyUrl' => 'localhost/notify',
-                'termsUrl' => 'localhost/terms',
-                'currency' => 'EUR',
-                'validationUrl' => 'localhost/validate',
-                'shipping_countries' => ['NL', 'DE'],
-                'purchase_country' => 'BE',
-            ]
+            array_merge(
+                [
+                    'locale' => 'nl_NL',
+                    'amount' => '100.00',
+                    'tax_amount' => 21,
+                    'currency' => 'EUR',
+                    'shipping_countries' => ['NL', 'DE'],
+                    'purchase_country' => 'BE',
+                ],
+                $this->getMinimalValidMerchantUrlData()
+            )
         );
         $this->authorizeRequest->setItems([$this->getItemMock()]);
         $this->authorizeRequest->setWidgetOptions($widgetOptions);
@@ -243,13 +224,7 @@ class AuthorizeRequestTest extends RequestTestCase
                 'order_amount' => 10000,
                 'order_tax_amount' => 2100,
                 'order_lines' => [$this->getExpectedOrderLine()],
-                'merchant_urls' => [
-                    'checkout' => 'localhost/return',
-                    'confirmation' => 'localhost/return',
-                    'push' => 'localhost/notify',
-                    'terms' => 'localhost/terms',
-                    'validation' => 'localhost/validate',
-                ],
+                'merchant_urls' => $this->getMinimalExpectedMerchantUrlData(),
                 'purchase_country' => 'BE',
                 'purchase_currency' => 'EUR',
                 'options' => $widgetOptions,
@@ -267,18 +242,16 @@ class AuthorizeRequestTest extends RequestTestCase
         ];
 
         $this->authorizeRequest->initialize(
-            [
-                'cancellationTermsUrl' => 'localhost/cancellation-terms',
-                'locale' => 'nl_NL',
-                'amount' => '100.00',
-                'tax_amount' => 21,
-                'returnUrl' => 'localhost/return',
-                'notifyUrl' => 'localhost/notify',
-                'termsUrl' => 'localhost/terms',
-                'currency' => 'EUR',
-                'validationUrl' => 'localhost/validate',
-                'purchase_country' => 'FR',
-            ]
+            array_merge(
+                [
+                    'locale' => 'nl_NL',
+                    'amount' => '100.00',
+                    'tax_amount' => 21,
+                    'currency' => 'EUR',
+                    'purchase_country' => 'FR',
+                ],
+                $this->getCompleteValidMerchantUrlData()
+            )
         );
         $this->authorizeRequest->setCustomer($customer);
         $this->authorizeRequest->setItems([$this->getItemMock()]);
@@ -289,14 +262,7 @@ class AuthorizeRequestTest extends RequestTestCase
                 'order_amount' => 10000,
                 'order_tax_amount' => 2100,
                 'order_lines' => [$this->getExpectedOrderLine()],
-                'merchant_urls' => [
-                    'cancellation_terms' => 'localhost/cancellation-terms',
-                    'checkout' => 'localhost/return',
-                    'confirmation' => 'localhost/return',
-                    'push' => 'localhost/notify',
-                    'terms' => 'localhost/terms',
-                    'validation' => 'localhost/validate',
-                ],
+                'merchant_urls' => $this->getCompleteExpectedMerchantUrlData(),
                 'purchase_country' => 'FR',
                 'purchase_currency' => 'EUR',
                 'customer' => $customer,

--- a/tests/Message/MerchantUrlsDataTestTrait.php
+++ b/tests/Message/MerchantUrlsDataTestTrait.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace MyOnlineStore\Tests\Omnipay\KlarnaCheckout\Message;
+
+trait MerchantUrlsDataTestTrait
+{
+    /**
+     * @return array
+     */
+    public function getCompleteExpectedMerchantUrlData()
+    {
+        return [
+            'address_update' => 'localhost/address-update',
+            'cancellation_terms' => 'localhost/cancellation-terms',
+            'checkout' => 'localhost/return',
+            'confirmation' => 'localhost/return',
+            'push' => 'localhost/notify',
+            'terms' => 'localhost/terms',
+            'validation' => 'localhost/validate',
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getCompleteValidMerchantUrlData()
+    {
+        return [
+            'addressUpdateUrl' => 'localhost/address-update',
+            'cancellationTermsUrl' => 'localhost/cancellation-terms',
+            'returnUrl' => 'localhost/return',
+            'notifyUrl' => 'localhost/notify',
+            'termsUrl' => 'localhost/terms',
+            'validationUrl' => 'localhost/validate',
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getMinimalExpectedMerchantUrlData()
+    {
+        return [
+            'checkout' => 'localhost/return',
+            'confirmation' => 'localhost/return',
+            'push' => 'localhost/notify',
+            'terms' => 'localhost/terms',
+            'validation' => 'localhost/validate',
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getMinimalValidMerchantUrlData()
+    {
+        return [
+            'returnUrl' => 'localhost/return',
+            'notifyUrl' => 'localhost/notify',
+            'termsUrl' => 'localhost/terms',
+            'validationUrl' => 'localhost/validate',
+        ];
+    }
+}


### PR DESCRIPTION
If sufficient data is available, the update request now updates the set of merchant urls as well. Note: this will override the complete merchant_url object