### PR TITLE
Setter of `exclude_empty_values` attribute is now named consistently in order to allow it to be initialized

### DIFF
--- a/src/Message/UpdateCustomerAddressRequest.php
+++ b/src/Message/UpdateCustomerAddressRequest.php
@@ -17,15 +17,15 @@ final class UpdateCustomerAddressRequest extends AbstractOrderRequest
         $this->validate('transactionReference', 'billing_address', 'shipping_address');
 
         return [
-            'shipping_address' => $this->getShippingAddress()->toArray($this->getExcludeKeysWithEmptyValues()),
-            'billing_address' => $this->getBillingAddress()->toArray($this->getExcludeKeysWithEmptyValues()),
+            'shipping_address' => $this->getShippingAddress()->toArray($this->getExcludeEmptyValues()),
+            'billing_address' => $this->getBillingAddress()->toArray($this->getExcludeEmptyValues()),
         ];
     }
 
     /**
      * @return array
      */
-    public function getExcludeKeysWithEmptyValues()
+    public function getExcludeEmptyValues()
     {
         $exludedKeys = $this->getParameter('exclude_empty_values');
 
@@ -58,7 +58,7 @@ final class UpdateCustomerAddressRequest extends AbstractOrderRequest
      *
      * @return $this
      */
-    public function setExcludeKeysWithEmptyValues(array $exludedKeys)
+    public function setExcludeEmptyValues(array $exludedKeys)
     {
         $this->setParameter('exclude_empty_values', $exludedKeys);
 

--- a/tests/Message/UpdateCustomerAddressRequestTest.php
+++ b/tests/Message/UpdateCustomerAddressRequestTest.php
@@ -127,7 +127,7 @@ final class UpdateCustomerAddressRequestTest extends RequestTestCase
                 'transactionReference' => 123,
                 'billing_address' => $addressData,
                 'shipping_address' => $addressData,
-                'exclude_keys_with_empty_values' => ['organization_name'],
+                'exclude_empty_values' => ['organization_name'],
             ]
         );
 
@@ -182,11 +182,11 @@ final class UpdateCustomerAddressRequestTest extends RequestTestCase
         self::assertTrue($updateCustomerAddressResponse->isSuccessful());
     }
 
-    public function testSetAndGetExcludeKeysWithEmptyValues()
+    public function testSetAndGetExcludeEmptyValues()
     {
         $parameters = ['foo'];
-        $this->updateCustomerAddressRequest->setExcludeKeysWithEmptyValues($parameters);
+        $this->updateCustomerAddressRequest->setExcludeEmptyValues($parameters);
 
-        self::assertSame($parameters, $this->updateCustomerAddressRequest->getExcludeKeysWithEmptyValues());
+        self::assertSame($parameters, $this->updateCustomerAddressRequest->getExcludeEmptyValues());
     }
 }


### PR DESCRIPTION
The inconsistent naming caused any value given during initialization to be discarded, since it could not find a corresponding setter (Omnipay magic).