### PR TITLE
remove deprecated merchant_id and use username instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Introduction
 
 [Omnipay](https://github.com/thephpleague/omnipay) is a framework agnostic, multi-gateway payment
-processing library for PHP 5.3+. This package implements Klarna Checkout support for Omnipay.
+processing library for PHP 5.6+. This package implements Klarna Checkout support for Omnipay.
 
 ## Installation
 

--- a/src/AuthenticationRequestOptionProvider.php
+++ b/src/AuthenticationRequestOptionProvider.php
@@ -7,8 +7,6 @@ use MyOnlineStore\Omnipay\KlarnaCheckout\Message\AbstractRequest;
 final class AuthenticationRequestOptionProvider
 {
     /**
-     * @todo fallback to getMerchantId can be removed in next major version
-     *
      * @param AbstractRequest $request
      *
      * @return array
@@ -17,7 +15,7 @@ final class AuthenticationRequestOptionProvider
     {
         return [
             'auth' => [
-                !empty($request->getMerchantId()) ? $request->getMerchantId() : $request->getUsername(),
+                $request->getUsername(),
                 $request->getSecret(),
             ],
         ];

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -78,21 +78,10 @@ final class Gateway extends AbstractGateway implements GatewayInterface
     {
         return [
             'api_region' => self::API_VERSION_EUROPE,
-            'merchant_id' => '',
             'secret' => '',
             'testMode' => true,
             'username' => '',
         ];
-    }
-
-    /**
-     * @deprecated use getUsername instead
-     *
-     * @return string
-     */
-    public function getMerchantId()
-    {
-        return $this->getParameter('merchant_id');
     }
 
     /**
@@ -151,20 +140,6 @@ final class Gateway extends AbstractGateway implements GatewayInterface
     public function setApiRegion($region)
     {
         $this->setParameter('api_region', $region);
-
-        return $this;
-    }
-
-    /**
-     * @deprecated use setUsername instead
-     *
-     * @param string $merchantId
-     *
-     * @return $this
-     */
-    public function setMerchantId($merchantId)
-    {
-        $this->setParameter('merchant_id', $merchantId);
 
         return $this;
     }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -66,16 +66,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     }
 
     /**
-     * @deprecated use getUsername instead
-     *
-     * @return string
-     */
-    public function getMerchantId()
-    {
-        return $this->getParameter('merchant_id');
-    }
-
-    /**
      * @return string|null
      */
     public function getMerchantReference1()
@@ -159,20 +149,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     public function setLocale($locale)
     {
         $this->setParameter('locale', $locale);
-    }
-
-    /**
-     * @deprecated use setUsername instead
-     *
-     * @param string $merchantId
-     *
-     * @return $this
-     */
-    public function setMerchantId($merchantId)
-    {
-        $this->setParameter('merchant_id', $merchantId);
-
-        return $this;
     }
 
     /**

--- a/tests/AuthenticationRequestOptionProviderTest.php
+++ b/tests/AuthenticationRequestOptionProviderTest.php
@@ -7,28 +7,12 @@ use MyOnlineStore\Omnipay\KlarnaCheckout\Message\AbstractRequest;
 
 final class AuthenticationRequestOptionProviderTest extends \PHPUnit_Framework_TestCase
 {
-    public function testWithMerchantIdSetWillReturnOptionsWithMerchantId()
+    public function testWillReturnOptions()
     {
         $request = $this->getMockBuilder(AbstractRequest::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $request->expects(self::exactly(2))->method('getMerchantId')->will(self::returnValue('foobar'));
-        $request->expects(self::once())->method('getSecret')->will(self::returnValue('barbaz'));
-
-        self::assertEquals(
-            ['auth' => ['foobar', 'barbaz']],
-            (new AuthenticationRequestOptionProvider())->getOptions($request)
-        );
-    }
-
-    public function testWithNoMerchantIdSetWillReturnOptionsWithUsername()
-    {
-        $request = $this->getMockBuilder(AbstractRequest::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $request->expects(self::once())->method('getMerchantId')->will(self::returnValue(null));
         $request->expects(self::once())->method('getUsername')->will(self::returnValue('foobar'));
         $request->expects(self::once())->method('getSecret')->will(self::returnValue('barbaz'));
 

--- a/tests/Message/ExtendAuthorizationRequestTest.php
+++ b/tests/Message/ExtendAuthorizationRequestTest.php
@@ -52,7 +52,7 @@ final class ExtendAuthorizationRequestTest extends RequestTestCase
         $this->extendAuthorizationRequest->initialize(
             [
                 'base_url' => self::BASE_URL,
-                'merchant_id' => self::USERNAME,
+                'username' => self::USERNAME,
                 'secret' => self::SECRET,
                 'transactionReference' => 'foo',
             ]

--- a/tests/Message/UpdateCustomerAddressRequestTest.php
+++ b/tests/Message/UpdateCustomerAddressRequestTest.php
@@ -164,7 +164,7 @@ final class UpdateCustomerAddressRequestTest extends RequestTestCase
         $this->updateCustomerAddressRequest->initialize(
             [
                 'base_url' => self::BASE_URL,
-                'merchant_id' => self::USERNAME,
+                'username' => self::USERNAME,
                 'secret' => self::SECRET,
                 'transactionReference' => $transactionReference,
             ]


### PR DESCRIPTION
to be tagged as version 2.0 to be in line with the version numbers omnipay uses

see: https://github.com/thephpleague/omnipay