### PR TITLE
RB-11769 - Allow empty item data set (no orderlines)

### DIFF
--- a/src/Message/AbstractOrderRequest.php
+++ b/src/Message/AbstractOrderRequest.php
@@ -3,6 +3,7 @@
 namespace MyOnlineStore\Omnipay\KlarnaCheckout\Message;
 
 use MyOnlineStore\Omnipay\KlarnaCheckout\Address;
+use MyOnlineStore\Omnipay\KlarnaCheckout\ItemBag;
 use MyOnlineStore\Omnipay\KlarnaCheckout\WidgetOptions;
 use MyOnlineStore\Omnipay\KlarnaCheckout\Customer;
 
@@ -178,7 +179,7 @@ abstract class AbstractOrderRequest extends AbstractRequest
         $data = [
             'order_amount' => $this->getAmountInteger(),
             'order_tax_amount' => $this->toCurrencyMinorUnits($this->getTaxAmount()),
-            'order_lines' => $this->getItemData($this->getItems()),
+            'order_lines' => $this->getItemData($this->getItems() ?? new ItemBag()),
             'purchase_currency' => $this->getCurrency(),
             'purchase_country' => $this->getPurchaseCountry(),
         ];

--- a/src/Message/AbstractOrderRequest.php
+++ b/src/Message/AbstractOrderRequest.php
@@ -179,7 +179,7 @@ abstract class AbstractOrderRequest extends AbstractRequest
         $data = [
             'order_amount' => $this->getAmountInteger(),
             'order_tax_amount' => $this->toCurrencyMinorUnits($this->getTaxAmount()),
-            'order_lines' => $this->getItemData($this->getItems() ?? new ItemBag()),
+            'order_lines' => $this->getItemData($this->getItems() ?: new ItemBag()),
             'purchase_currency' => $this->getCurrency(),
             'purchase_country' => $this->getPurchaseCountry(),
         ];

--- a/tests/Message/UpdateTransactionRequestTest.php
+++ b/tests/Message/UpdateTransactionRequestTest.php
@@ -78,6 +78,36 @@ class UpdateTransactionRequestTest extends RequestTestCase
         );
     }
 
+    public function testGetDataWillReturnCorrectDataForEmptyCart()
+    {
+        $this->updateTransactionRequest->initialize(
+            [
+                'amount' => '100.00',
+                'tax_amount' => 21,
+                'currency' => 'EUR',
+                'transactionReference' => self::TRANSACTION_REFERENCE,
+                'gui_minimal_confirmation' => true,
+                'gui_autofocus' => false,
+                'merchant_reference1' => '12345',
+                'merchant_reference2' => 678,
+                'purchase_country' => 'FR',
+            ]
+        );
+        self::assertEquals(
+            [
+                'order_amount' => 10000,
+                'order_tax_amount' => 2100,
+                'order_lines' => [],
+                'purchase_currency' => 'EUR',
+                'gui' => ['options' => ['disable_autofocus', 'minimal_confirmation']],
+                'merchant_reference1' => '12345',
+                'merchant_reference2' => 678,
+                'purchase_country' => 'FR',
+            ],
+            $this->updateTransactionRequest->getData()
+        );
+    }
+
     public function testGetDataWithAddressWillReturnCorrectData()
     {
         $organization = 'Foo inc';


### PR DESCRIPTION
Adds https://github.com/MyOnlineStore/omnipay-klarna-checkout/pull/56 for version 2

https://rollbar.com/sandwich/MOS/items/11769/ still occurs, because it was applied to master (= v3), which we're not yet using... :man_facepalming: 