### PR TITLE
Reset `base_url` when `setTestMode()` is called

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -204,11 +204,9 @@ final class Gateway extends AbstractGateway implements GatewayInterface
         if (self::API_VERSION_EUROPE === $this->getApiRegion()) {
             $this->parameters->set('base_url', $this->getTestMode() ? self::EU_TEST_BASE_URL : self::EU_BASE_URL);
 
-            return $this;
+            return;
         }
 
         $this->parameters->set('base_url', $this->getTestMode() ? self::NA_TEST_BASE_URL : self::NA_BASE_URL);
-
-        return $this;
     }
 }

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -117,11 +117,7 @@ final class Gateway extends AbstractGateway implements GatewayInterface
     {
         parent::initialize($parameters);
 
-        if (self::API_VERSION_EUROPE === $this->getApiRegion()) {
-            $this->parameters->set('base_url', $this->getTestMode() ? self::EU_TEST_BASE_URL : self::EU_BASE_URL);
-        } else {
-            $this->parameters->set('base_url', $this->getTestMode() ? self::NA_TEST_BASE_URL : self::NA_BASE_URL);
-        }
+        $this->setBaseUrl();
 
         return $this;
     }
@@ -170,6 +166,13 @@ final class Gateway extends AbstractGateway implements GatewayInterface
         return $this;
     }
 
+    public function setTestMode($testMode): self
+    {
+        $this->setParameter('testMode', $testMode);
+        $this->setBaseUrl();
+        return $this;
+    }
+
     /**
      * @inheritDoc
      */
@@ -192,5 +195,14 @@ final class Gateway extends AbstractGateway implements GatewayInterface
     public function void(array $options = [])
     {
         return $this->createRequest(VoidRequest::class, $options);
+    }
+
+    private function setBaseUrl()
+    {
+        if (self::API_VERSION_EUROPE === $this->getApiRegion()) {
+            $this->parameters->set('base_url', $this->getTestMode() ? self::EU_TEST_BASE_URL : self::EU_BASE_URL);
+        } else {
+            $this->parameters->set('base_url', $this->getTestMode() ? self::NA_TEST_BASE_URL : self::NA_BASE_URL);
+        }
     }
 }

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -168,8 +168,10 @@ final class Gateway extends AbstractGateway implements GatewayInterface
 
     public function setTestMode($testMode): self
     {
-        $this->setParameter('testMode', $testMode);
+        parent::setTestMode($testMode);
+
         $this->setBaseUrl();
+
         return $this;
     }
 
@@ -201,8 +203,12 @@ final class Gateway extends AbstractGateway implements GatewayInterface
     {
         if (self::API_VERSION_EUROPE === $this->getApiRegion()) {
             $this->parameters->set('base_url', $this->getTestMode() ? self::EU_TEST_BASE_URL : self::EU_BASE_URL);
-        } else {
-            $this->parameters->set('base_url', $this->getTestMode() ? self::NA_TEST_BASE_URL : self::NA_BASE_URL);
+
+            return $this;
         }
+
+        $this->parameters->set('base_url', $this->getTestMode() ? self::NA_TEST_BASE_URL : self::NA_BASE_URL);
+
+        return $this;
     }
 }

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -81,6 +81,20 @@ final class GatewayTest extends GatewayTestCase
         self::assertEquals($expectedUrl, $this->gateway->getParameter('base_url'));
     }
 
+    /**
+     * @dataProvider baseUrlDataProvider
+     *
+     * @param bool   $testMode
+     * @param string $region
+     * @param string $expectedUrl
+     */
+    public function testSetTestModeWillSetCorrectBaseUrl($testMode, $region, $expectedUrl)
+    {
+        $this->gateway->initialize(['api_region' => $region]);
+        $this->gateway->setTestMode($testMode);
+        self::assertEquals($expectedUrl, $this->gateway->getParameter('base_url'));
+    }
+
     public function testRefund()
     {
         $this->assertInstanceOf(RefundRequest::class, $this->gateway->refund());


### PR DESCRIPTION
When `setTestMode()` is called the `base_url` value is likely to change. Currently the `base_url` can only be set on `initialize()` call so any changes to `testMode` after that will not update the `base_url` value.