### PR TITLE
Add total_amount and total_discount_amount

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -24,9 +24,25 @@ final class Item extends \Omnipay\Common\Item implements ItemInterface
     /**
      * @inheritDoc
      */
+    public function getTotalAmount()
+    {
+        return $this->getParameter('total_amount');
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function getTotalTaxAmount()
     {
         return $this->getParameter('total_tax_amount');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTotalDiscountAmount()
+    {
+        return $this->getParameter('total_discount_amount');
     }
 
     /**
@@ -56,9 +72,25 @@ final class Item extends \Omnipay\Common\Item implements ItemInterface
     /**
      * @param int $amount
      */
+    public function setTotalAmount($amount)
+    {
+        $this->setParameter('total_amount', $amount);
+    }
+
+    /**
+     * @param int $amount
+     */
     public function setTotalTaxAmount($amount)
     {
         $this->setParameter('total_tax_amount', $amount);
+    }
+
+    /**
+     * @param int $amount
+     */
+    public function setTotalDiscountAmount($amount)
+    {
+        $this->setParameter('total_discount_amount', $amount);
     }
 
     /**

--- a/src/Item.php
+++ b/src/Item.php
@@ -32,17 +32,17 @@ final class Item extends \Omnipay\Common\Item implements ItemInterface
     /**
      * @inheritDoc
      */
-    public function getTotalTaxAmount()
+    public function getTotalDiscountAmount()
     {
-        return $this->getParameter('total_tax_amount');
+        return $this->getParameter('total_discount_amount');
     }
 
     /**
      * @inheritDoc
      */
-    public function getTotalDiscountAmount()
+    public function getTotalTaxAmount()
     {
-        return $this->getParameter('total_discount_amount');
+        return $this->getParameter('total_tax_amount');
     }
 
     /**
@@ -80,17 +80,17 @@ final class Item extends \Omnipay\Common\Item implements ItemInterface
     /**
      * @param int $amount
      */
-    public function setTotalTaxAmount($amount)
+    public function setTotalDiscountAmount($amount)
     {
-        $this->setParameter('total_tax_amount', $amount);
+        $this->setParameter('total_discount_amount', $amount);
     }
 
     /**
      * @param int $amount
      */
-    public function setTotalDiscountAmount($amount)
+    public function setTotalTaxAmount($amount)
     {
-        $this->setParameter('total_discount_amount', $amount);
+        $this->setParameter('total_tax_amount', $amount);
     }
 
     /**

--- a/src/ItemInterface.php
+++ b/src/ItemInterface.php
@@ -25,18 +25,18 @@ interface ItemInterface extends \Omnipay\Common\ItemInterface
     public function getTotalAmount();
 
     /**
-     * Total amount of tax
-     *
-     * @return float|null
-     */
-    public function getTotalTaxAmount();
-
-    /**
      * Total amount of discount
      *
      * @return float|null
      */
     public function getTotalDiscountAmount();
+
+    /**
+     * Total amount of tax
+     *
+     * @return float|null
+     */
+    public function getTotalTaxAmount();
 
     /**
      * Product type

--- a/src/ItemInterface.php
+++ b/src/ItemInterface.php
@@ -18,11 +18,25 @@ interface ItemInterface extends \Omnipay\Common\ItemInterface
     public function getTaxRate();
 
     /**
+     * Total amount
+     *
+     * @return float|null
+     */
+    public function getTotalAmount();
+
+    /**
      * Total amount of tax
      *
      * @return float|null
      */
     public function getTotalTaxAmount();
+
+    /**
+     * Total amount of discount
+     *
+     * @return float|null
+     */
+    public function getTotalDiscountAmount();
 
     /**
      * Product type

--- a/src/Message/ItemDataTrait.php
+++ b/src/Message/ItemDataTrait.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace MyOnlineStore\Omnipay\KlarnaCheckout\Message;

--- a/src/Message/ItemDataTrait.php
+++ b/src/Message/ItemDataTrait.php
@@ -19,18 +19,27 @@ trait ItemDataTrait
 
         foreach ($items as $item) {
             $taxRate = $item->getTaxRate();
+            $price = null === $item->getPrice()
+                ? $this->convertToMoney(0)
+                : $this->convertToMoney($item->getPrice());
             $totalTaxAmount = null === $item->getTotalTaxAmount()
                 ? $this->convertToMoney(0)
                 : $this->convertToMoney($item->getTotalTaxAmount());
-            $price = null === $item->getPrice() ? $this->convertToMoney(0) : $this->convertToMoney($item->getPrice());
+            $totalDiscountAmount = null === $item->getTotalDiscountAmount()
+                ? $this->convertToMoney(0)
+                : $this->convertToMoney($item->getTotalDiscountAmount());
+            $totalAmount = null === $item->getTotalAmount()
+                ? $price->multiply($item->getQuantity())
+                : $this->convertToMoney($item->getTotalAmount());
 
             $orderLines[] = [
                 'type' => $item->getType(),
                 'name' => $item->getName(),
                 'quantity' => $item->getQuantity(),
                 'tax_rate' => null === $taxRate ? 0 : (int) ($item->getTaxRate() * 100),
-                'total_amount' => (int) $price->multiply($item->getQuantity())->getAmount(),
+                'total_amount' => (int) $totalAmount->getAmount(),
                 'total_tax_amount' => (int) $totalTaxAmount->getAmount(),
+                'total_discount_amount' => (int) $totalDiscountAmount->getAmount(),
                 'unit_price' => (int) $price->getAmount(),
                 'merchant_data' => $item->getMerchantData(),
             ];

--- a/src/Message/ItemDataTrait.php
+++ b/src/Message/ItemDataTrait.php
@@ -19,9 +19,7 @@ trait ItemDataTrait
 
         foreach ($items as $item) {
             $taxRate = $item->getTaxRate();
-            $price = null === $item->getPrice()
-                ? $this->convertToMoney(0)
-                : $this->convertToMoney($item->getPrice());
+            $price = null === $item->getPrice() ? $this->convertToMoney(0) : $this->convertToMoney($item->getPrice());
             $totalTaxAmount = null === $item->getTotalTaxAmount()
                 ? $this->convertToMoney(0)
                 : $this->convertToMoney($item->getTotalTaxAmount());

--- a/src/Message/ItemDataTrait.php
+++ b/src/Message/ItemDataTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MyOnlineStore\Omnipay\KlarnaCheckout\Message;
@@ -27,7 +28,7 @@ trait ItemDataTrait
                 ? $this->convertToMoney(0)
                 : $this->convertToMoney($item->getTotalDiscountAmount());
             $totalAmount = null === $item->getTotalAmount()
-                ? $price->multiply($item->getQuantity())
+                ? $price->multiply($item->getQuantity())->subtract($totalDiscountAmount)
                 : $this->convertToMoney($item->getTotalAmount());
 
             $orderLines[] = [

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace MyOnlineStore\Tests\Omnipay\KlarnaCheckout;

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MyOnlineStore\Tests\Omnipay\KlarnaCheckout;
@@ -12,17 +13,23 @@ final class ItemTest extends TestCase
     {
         $taxRate = 21;
         $totalTaxAmount = 9.45;
+        $totalAmount = ($totalTaxAmount / $taxRate) * 100;
+        $totalDiscountAmount = 1.00;
         $type = 'shipping_fee';
         $merchantData = 'foobar';
 
         $item = new Item();
         $item->setTaxRate($taxRate);
         $item->setTotalTaxAmount($totalTaxAmount);
+        $item->setTotalAmount($totalAmount);
+        $item->setTotalDiscountAmount($totalDiscountAmount);
         $item->setType($type);
         $item->setMerchantData($merchantData);
 
         self::assertEquals($taxRate, $item->getTaxRate());
         self::assertEquals($totalTaxAmount, $item->getTotalTaxAmount());
+        self::assertEquals($totalAmount, $item->getTotalAmount());
+        self::assertEquals($totalDiscountAmount, $item->getTotalDiscountAmount());
         self::assertEquals($type, $item->getType());
         self::assertEquals($merchantData, $item->getMerchantData());
     }

--- a/tests/Message/ItemDataTestTrait.php
+++ b/tests/Message/ItemDataTestTrait.php
@@ -16,6 +16,7 @@ trait ItemDataTestTrait
             'tax_rate' => 2003,
             'total_amount' => 10000,
             'total_tax_amount' => 20000,
+            'total_discount_amount' => 0,
             'unit_price' => 10000,
             'merchant_data' => 'foobar',
         ];
@@ -33,7 +34,9 @@ trait ItemDataTestTrait
         $item->method('getTaxRate')->willReturn(20.03);
         $item->method('getQuantity')->willReturn(1);
         $item->method('getPrice')->willReturn(100);
+        $item->method('getTotalAmount')->willReturn(100);
         $item->method('getTotalTaxAmount')->willReturn(200);
+        $item->method('getTotalDiscountAmount')->willReturn(0);
         $item->method('getMerchantData')->willReturn('foobar');
 
         return $item;


### PR DESCRIPTION
Our store adds discounts on to items before VAT / tax is calculated. This was proving a problem in Klarna causing the  `Bad value: total_tax_amount` or `Bad value: total_amount` errors.

This PR adds the ability to set a `total_discount_amount` item parameter (which defaults to 0) and `total_amount` (which still defaults to `price * quantity`).