### PR TITLE
Allow organizations and companies to checkout

### DIFF
--- a/src/WidgetOptions.php
+++ b/src/WidgetOptions.php
@@ -29,6 +29,7 @@ final class WidgetOptions extends \ArrayObject
             'show_subtotal_detail' => false,
             'require_validate_callback_success' => false,
             'allow_global_billing_countries' => false,
+            'allowed_customer_types' => 'person',
         ];
 
         return new self(array_merge($defaults, array_intersect_key($data, $defaults)));

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -255,6 +255,7 @@ class AuthorizeRequestTest extends RequestTestCase
             'show_subtotal_detail' => true,
             'require_validate_callback_success' => true,
             'allow_global_billing_countries' => false,
+            'allowed_customer_types' => 'person'
         ];
 
         $this->authorizeRequest->initialize(

--- a/tests/Message/UpdateTransactionRequestTest.php
+++ b/tests/Message/UpdateTransactionRequestTest.php
@@ -310,6 +310,7 @@ class UpdateTransactionRequestTest extends RequestTestCase
             'show_subtotal_detail' => true,
             'require_validate_callback_success' => true,
             'allow_global_billing_countries' => false,
+            'allowed_customer_types' => 'person',
         ];
 
         $this->updateTransactionRequest->initialize(
@@ -322,7 +323,7 @@ class UpdateTransactionRequestTest extends RequestTestCase
                 'gui_minimal_confirmation' => true,
                 'gui_autofocus' => false,
                 'merchant_reference1' => '12345',
-                'merchant_reference2' => 678,
+                'merchant_reference2' => '678',
                 'purchase_country' => 'DE',
             ]
         );
@@ -341,7 +342,7 @@ class UpdateTransactionRequestTest extends RequestTestCase
                 'purchase_currency' => 'EUR',
                 'gui' => ['options' => ['disable_autofocus', 'minimal_confirmation']],
                 'merchant_reference1' => '12345',
-                'merchant_reference2' => 678,
+                'merchant_reference2' => '678',
                 'options' => $widgetOptions,
             ],
             $this->updateTransactionRequest->getData()

--- a/tests/Message/WidgetOptionsTest.php
+++ b/tests/Message/WidgetOptionsTest.php
@@ -57,6 +57,7 @@ final class WidgetOptionsTest extends TestCase
                     'show_subtotal_detail' => true,
                     'require_validate_callback_success' => true,
                     'allow_global_billing_countries' => false,
+                    'allowed_customer_types' => 'person',
                 ],
             ],
             [
@@ -78,6 +79,7 @@ final class WidgetOptionsTest extends TestCase
                     'show_subtotal_detail' => false,
                     'require_validate_callback_success' => false,
                     'allow_global_billing_countries' => false,
+                    'allowed_customer_types' => 'person',
                 ],
             ],
             [
@@ -99,6 +101,7 @@ final class WidgetOptionsTest extends TestCase
                     'show_subtotal_detail' => false,
                     'require_validate_callback_success' => false,
                     'allow_global_billing_countries' => false,
+                    'allowed_customer_types' => 'person',
                 ],
             ],
         ];


### PR DESCRIPTION
Create an order with these options to allow companyies to checkout: 
`$order['widget_options']['allowed_customer_types']` = ['person', `'organization'];`

https://developers.klarna.com/api/#checkout-api-callbacks__order-validationoptions__allowed_customer_types