### PR TITLE
support completeAuthorize (simply calls acknowledge)

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -36,6 +36,14 @@ final class Gateway extends AbstractGateway implements GatewayInterface
     /**
      * @inheritdoc
      */
+    public function completeAuthorize(array $options = array()): RequestInterface
+    {
+        return $this->acknowledge($options);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function authorize(array $options = [])
     {
         return $this->createRequest(AuthorizeRequest::class, $options);


### PR DESCRIPTION
Allows existing code that relies on `authorize` -> `completeAuthorize` -> `capture` logic to continue working for PSP agnostic consumers.

Closes #69.