### PR TITLE
chore!: Removed fallback behavior from update-transaction request

### DIFF
--- a/src/Message/UpdateTransactionRequest.php
+++ b/src/Message/UpdateTransactionRequest.php
@@ -40,30 +40,15 @@ final class UpdateTransactionRequest extends AbstractOrderRequest
      */
     public function sendData($data)
     {
-        $responseData = $this->getResponseBody(
-            $this->sendRequest(
-                'POST',
-                \sprintf('/checkout/v3/orders/%s', $this->getTransactionReference()),
-                $data
+        return new UpdateTransactionResponse(
+            $this,
+            $this->getResponseBody(
+                $this->sendRequest(
+                    'POST',
+                    \sprintf('/checkout/v3/orders/%s', $this->getTransactionReference()),
+                    $data
+                )
             )
         );
-
-        // Once the checkout order has reached it's end-state it cannot be changed; update the management order instead
-        if (isset($responseData['error_code']) && 'READ_ONLY_ORDER' === $responseData['error_code']) {
-            // Attempt to update the merchant references at the order management endpoint
-            $requestData = \array_intersect_key($data, ['merchant_reference1' => true, 'merchant_reference2' => true]);
-
-            $responseData = !empty($requestData) ?
-                $this->getResponseBody(
-                    $this->sendRequest(
-                        'PATCH',
-                        \sprintf('/ordermanagement/v1/orders/%s/merchant-references', $this->getTransactionReference()),
-                        $requestData
-                    )
-                ) :
-                []; // no merchant references to be updated
-        }
-
-        return new UpdateTransactionResponse($this, $responseData);
     }
 }


### PR DESCRIPTION
This should be released as a new major version due to BC breaks.

Update transaction request will no longer fall back to updating only the merchant references at the order management API, when the checkout order itself could not be updated due to being read-only.

This fallback mechanism resulted in the request appearing to always succeed, because it interprets the response of this fallback request.

To simulate the old behavior, the client application has to inspect the `isSuccessful` result of the `UpdateTransactionResponse`, and do a follow-up `UpdateMerchantReferencesRequest` when the checkout order update was unsuccessful.